### PR TITLE
rodeo build (rez, houdini-19.5.435, python3.7m)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ endif()
 
 set(AR_PXR_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR})
 # Python
-set(AR_PYTHON_LIB python3.9)
-set(AR_PYTHON_LIB_NUMBER python39)
+set(AR_PYTHON_LIB "python$ENV{REZ_PYTHON_MAJOR_VERSION}.$ENV{REZ_PYTHON_MINOR_VERSION}")
+set(AR_PYTHON_LIB_NUMBER "python$ENV{REZ_PYTHON_MAJOR_VERSION}$ENV{REZ_PYTHON_MINOR_VERSION}")
 if (WIN32)
     set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/${AR_PYTHON_LIB_NUMBER}/libs)
     set(AR_PYTHON_LIB_SITEPACKAGES ${AR_HOUDINI_ROOT}/${AR_PYTHON_LIB_NUMBER}/lib/site-packages)
@@ -94,7 +94,12 @@ else()
     set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/python/lib)
     set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
 endif()
+# Rodeo: python3.7 has suffix m https://discuss.python.org/t/whats-the-difference-between-python3-7-and-python3-7m/16914
 set(AR_PYTHON_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/${AR_PYTHON_LIB})
+if ("${AR_PYTHON_LIB}" STREQUAL "python3.7")
+	set(AR_PYTHON_INCLUDE_DIR ${AR_PYTHON_INCLUDE_DIR}m)
+endif()
+
 # Boost
 set(AR_BOOST_NAMESPACE hboost)
 if (WIN32)

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,13 @@
 # Clear current session log 
 clear
 # Source environment (Uncomment lines starting with "export" if you current env does not have these defined.)
-# export HFS=/opt/<InsertHoudiniVersion>
+export HFS=$HOUDINI_INSTALLATION_DIR
 # Define Resolver > Has to be one of 'fileResolver'/'pythonResolver'/'cachedResolver'/'httpResolver'
-# export RESOLVER_NAME=cachedResolver
+export RESOLVER_NAME=fileResolver
 # Clear existing build data and invoke cmake
-rm -R build
-rm -R dist
+
+rm -rf build
+rm -rf dist
 set -e # Exit on error
 cmake . -B build
 cmake --build build --clean-first              # make clean all

--- a/rdo_build.sh
+++ b/rdo_build.sh
@@ -1,0 +1,1 @@
+/rdo/rodeo/setup/rez/linux/current/bin/rez/rez env cmake houdini-19.5.435 -- scl enable devtoolset-6 ./build.sh

--- a/setup.sh
+++ b/setup.sh
@@ -5,10 +5,10 @@ then
     export REPO_SOURCED=1
     export REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && (pwd -W 2> /dev/null || pwd))
     # Define Resolver > Has to be one of 'fileResolver'/'pythonResolver'/'cachedResolver'/'httpResolver'
-    export RESOLVER_NAME=cachedResolver
+    export RESOLVER_NAME=fileResolver
     export RESOLVER_NAME_UPPERCASE=$(echo ${RESOLVER_NAME} | tr '[:lower:]' '[:upper:]')
     # Source Houdini (This defines what Houdini version to compile against)
-    pushd /opt/hfs19.5 > /dev/null
+    pushd $HOUDINI_INSTALLATION_DIR > /dev/null
     source houdini_setup
     popd > /dev/null
     export HOUDINI_LMINFO_VERBOSE=1


### PR DESCRIPTION
This PR sets up Rodeo build of the fileResolver.
- Fix CMakeLists.txt to support python3.7m (from in houdini installation)
- Fix build.sh to use houdini installation dir from rez env
- New file rdo_build.sh to wrap build.sh into a rez env (and scl enable) call