### PR TITLE
Fix absolute mapped path 

### DIFF
--- a/src/FileResolver/resolver.cpp
+++ b/src/FileResolver/resolver.cpp
@@ -151,6 +151,8 @@ FileResolver::_Resolve(
                     auto map_find = mappingPairs.find(mappedPath);
                     if(map_find != mappingPairs.end()){
                         mappedPath = map_find->second;
+                        if (!_IsRelativePath(mappedPath))
+                            return ArResolvedPath(mappedPath);
                     }
                     for (const auto& searchPath : ctx->GetSearchPaths()) {
                         ArResolvedPath resolvedPath = _ResolveAnchored(searchPath, mappedPath);


### PR DESCRIPTION
This PR fixes a small issue with resolved mapped paths.
Currently, it will try to find mapped path in search paths even though if absolute.
Change will simply resolve mapped path if absolute, without using search paths.