### PR TITLE
Don't check resolved path file existence

### DIFF
--- a/src/CachedResolver/resolver.cpp
+++ b/src/CachedResolver/resolver.cpp
@@ -75,7 +75,7 @@ _ResolveAnchored(
     if (!anchorPath.empty()) {
         resolvedPath = TfStringCatPaths(anchorPath, path);
     }
-    return TfPathExists(resolvedPath) ? ArResolvedPath(TfAbsPath(resolvedPath)) : ArResolvedPath();
+    return ArResolvedPath(TfAbsPath(resolvedPath));
 }
 
 CachedResolver::CachedResolver() = default;


### PR DESCRIPTION
Remove TfPathExists on resolved path because it's will ignore paths with <udim> (also may have a hit on file system?) 